### PR TITLE
fix: make it work in the Browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const Rabin = require('./rabin')
 const getRabin = require('../dist/rabin-wasm.node.js')
 
 const create = async (bits, min, max, windowSize) => {
-    compiled = await getRabin()
+    const compiled = await getRabin()
 
     return new Rabin(bits, min, max, windowSize, compiled)
 }


### PR DESCRIPTION
When using in the Browser it failed due to
`ReferenceError: compiled is not defined`.

Closes #4.